### PR TITLE
Added builton field

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -5,6 +5,7 @@
     - repo: matplotlib/matplotlib
       sponsors: [numfocus]
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: plotly/plotly.py
       sponsors: [plotly]
@@ -12,10 +13,12 @@
       conda_package: plotly
       site: https://plot.ly
       badges: circleci, pypi, conda, site
+      builton: plotly
 
     - repo: bokeh/bokeh
       sponsors: [numfocus, anaconda]
       badges: travis, pypi, conda, site
+      builton: bokeh
 
 - name: High-Level Shared API
   intro: Libraries sharing the Pandas .plot() API, built upon the core Python or JS libraries.
@@ -25,29 +28,35 @@
       sponsors: [numfocus]
       site: https://pandas.pydata.org
       badges: travis, appveyor, codecov, rtd, pypi, conda, site
+      builton: matplotlib
 
     - repo: pydata/xarray
       sponsors: [numfocus]
       appveyor_project: shoyer/xray
       site: https://xarray.pydata.org
       badges: travis, appveyor, coveralls, rtd, pypi, conda, site
+      builton: matplotlib
 
     - repo: santosjorge/cufflinks
       site: https://github.com/santosjorge/cufflinks/blob/master/README.md
       badges: circleci, pypi, site
+      builton: plotly
 
     - repo: pyviz/hvplot
       sponsors: [anaconda]
       site: https://hvplot.pyviz.org
       badges: travis, appveyor, pypi, conda, site
+      builton: bokeh
 
     - repo: PatrikHlobil/Pandas-Bokeh
       site: https://github.com/PatrikHlobil/Pandas-Bokeh/blob/master/README.md
       badges: pypi, site
+      builton: bokeh
 
     - repo: altair-viz/pdvega
       site: https://altair-viz.github.io/pdvega
       badges: travis, pypi, site
+      builton: vega
 
 - name: High-Level
   intro: InfoVis Libraries focusing on high-level operations for working with data visually, built upon the core Python or JS libraries.
@@ -56,27 +65,32 @@
     - repo: mwaskom/seaborn
       site: https://seaborn.pydata.org
       badges: travis, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: altair-viz/altair
       site: https://altair-viz.github.io
       conda_channel: conda-forge
       badges: travis, pypi, conda, site
+      builton: vega
 
     - repo: pyviz/holoviews
       sponsors: [anaconda]
       appveyor_project: pyviz/holoviews-ginxt
       badges: travis, appveyor, coveralls, pypi, conda, site
+      builton: bokeh, matplotlib, plotly
 
     - repo: plotly/plotly_express
       sponsors: [plotly]
       site: https://plotly.express
       badges: pypi, site
+      builton: plotly
 
     - repo: spotify/chartify
       sponsors: [spotify]
       conda_channel: conda-forge
       site: https://github.com/spotify/chartify/blob/master/README.rst
       badges: travis, pypi, conda, site
+      builton: bokeh
 
 - name: Native-GUI
   intro: InfoVis Libraries targetting native-desktop GUI interfaces for interactive plots (also see Matplotlib in core above).
@@ -114,7 +128,8 @@
     - repo: has2k1/plotnine
       conda_channel: conda-forge
       badges: pypi, conda, rtd
-
+      builton: matplotlib
+      
     - repo: bloomberg/bqplot
       conda_channel: conda-forge
       badges: pypi, conda, rtd
@@ -138,33 +153,40 @@
       site: https://vtk.org/
       conda_channel: conda-forge
       badges: travis, pypi, conda, site
+      builton: vtk
 
     - repo: vispy/vispy
       conda_channel: conda-forge
       site: http://vispy.org
       badges: travis, appveyor, coveralls, pypi, conda, site
+      builton: opengl
 
     - repo: maartenbreddels/ipyvolume
       conda_channel: conda-forge
+      builton: opengl, webgl
 
     - repo: enthought/mayavi
       sponsors: [enthought]
       site: https://docs.enthought.com/mayavi/mayavi
       appveyor_project: EnthoughtOSS/mayavi
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: vtk, opengl
 
     - repo: pyvista/pyvista
       site: https://docs.pyvista.org
       conda_channel: conda-forge
+      builton: vtk
 
     - repo: InsightSoftwareConsortium/itkwidgets
       pypi_name: itkwidgets
       conda_package: itkwidgets
       conda_channel: conda-forge
       badges: pypi, conda, circleci
+      builton: vtk
 
     - repo: glumpy/glumpy
       badges: pypi, rtd
+      builton: opengl
 
 - name: Geospatial
   intro: Tools for working with data in geographic coordinates.
@@ -173,15 +195,18 @@
     - repo: geopandas/geopandas
       site: http://geopandas.org
       conda_channel: conda-forge
+      builton: matplotlib
 
     - repo: python-visualization/folium
       site: https://python-visualization.github.io/folium
       conda_channel: conda-forge
+      builton: leaflet
 
     - repo: SciTools/cartopy
       sponsors: [metoffice]
       site: https://scitools.org.uk/cartopy
       badges: travis, appveyor, coveralls, pypi, conda, site
+      builton: matplotlib
 
     - repo: vgm64/gmplot
       badges: pypi
@@ -189,20 +214,24 @@
     - repo: jupyter-widgets/ipyleaflet
       conda_channel: conda-forge
       badges: pypi, conda, rtd
+      builton: leaflet
 
     - repo: pyviz/geoviews
       sponsors: [anaconda]
       site: http://geoviews.org
       badges: travis, appveyor, pypi, conda, site
+      builton: bokeh, matplotlib, plotly
 
     - repo: ResidentMario/geoplot
       site: https://residentmario.github.io/geoplot
       conda_channel: conda-forge
       badges: pypi, conda, site
+      builton: matplotlib
 
     - repo: andrea-cuttone/geoplotlib
       site: https://github.com/andrea-cuttone/geoplotlib/wiki/User-Guide
       badges: pypi
+      builton: opengl
 
 - name: Other domain-specific
   intro: Tools focused on specific research or application areas other than those above.
@@ -212,48 +241,58 @@
       site: https://networkx.github.io
       appveyor_project: dschult/networkx-pqott
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: scikit-image/scikit-image
       site: https://scikit-image.org
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: ResidentMario/missingno
       conda_channel: conda-forge
+      builton: matplotlib
 
     - repo: arviz-devs/arviz
       sponsors: [numfocus]
       site: https://arviz-devs.github.io/arviz
       conda_channel: conda-forge
       badges: pypi, travis, azure, coveralls, conda, site
+      builton: matplotlib
 
     - repo: reiinakano/scikit-plot
       site: https://github.com/reiinakano/scikit-plot
       conda_channel: conda-forge
       badges: pypi, conda, site
+      builton: matplotlib
 
     - repo: DistrictDataLabs/yellowbrick
       site: https://www.scikit-yb.org
       sponsors: [numfocus]
       conda_channel: DistrictDataLabs
       badges: travis, appveyor, pypi, conda, site
+      builton: matplotlib
 
     - repo: Unidata/MetPy
       sponsors: [unidata]
       site: https://unidata.github.io/MetPy
       conda_channel: conda-forge
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: yt-project/yt
       sponsors: [numfocus]
       site: https://yt-project.org
       badges: travis, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: ContextLab/hypertools
       badges: pypi, rtd
+      builton: matplotlib
 
     - repo: ismms-himc/clustergrammer2
       site: https://clustergrammer.readthedocs.io
       badges: pypi, site
+      builton: webgl
 
 - name: Large-data rendering
   intro: Tools for rasterizing/aggregating data before visualization, which can make rendering faster, allow larger datasets, or make it feasible to use remote datasets (with server-side rendering).
@@ -262,6 +301,7 @@
     - repo: astrofrog/mpl-scatter-density
       site: https://github.com/astrofrog/mpl-scatter-density
       badges: travis, appveyor, pypi, conda, site
+      builton: matplotlib
 
     - repo: pyviz/datashader
       sponsors: [anaconda]
@@ -283,11 +323,13 @@
       conda_channel: conda-forge
       site: https://dash.plot.ly
       badges: circleci, pypi, conda, site
+      builton: plotly
 
     - repo: pyviz/panel
       sponsors: [anaconda]
       site: https://panel.pyviz.org
       badges: travis, appveyor, codecov, pypi, conda, site
+      builton: bokeh
 
     - repo: streamlit/streamlit
       site: https://streamlit.io

--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -182,7 +182,7 @@
       conda_package: itkwidgets
       conda_channel: conda-forge
       badges: pypi, conda, circleci
-      builton: vtk
+      builton: webgl
 
     - repo: glumpy/glumpy
       badges: pypi, rtd


### PR DESCRIPTION
First step to addressing part of https://github.com/pyviz/pyviz.org/issues/7 , which is to declare which libraries are built on other libraries.  Added a "builton" field in the .yml, filling it out for nearly all the libraries. The current values include 20 libraries built on matplotlib, 7 on bokeh, etc.:

- 20 matplotlib
- &nbsp;&nbsp;7 bokeh
- &nbsp;&nbsp;6 plotly
- &nbsp;&nbsp;5 opengl
- &nbsp;&nbsp;4 vtk
- &nbsp;&nbsp;2 webgl
- &nbsp;&nbsp;2 vega
- &nbsp;&nbsp;2 leaflet

Issues:

1. For now, I counted bokeh, matplotlib, plotly, and vtk as building on themselves, but of course that's up for discussion.  
2. Are there any other technologies we should list?  My goals here are to (a) help people find the most suitable API for the tool they want to use, (b) understand how the various tools fit together, and (c) get a feeling for the capabilities of each library (e.g. 3D support, browser-based interactivity, etc.). Unfortunately, (c) is a slippery slope -- there are so many things that might be shown (SVG support, Canvas vs WebGL, PNG output, etc.), so I've focused on goals (a) and (b) here. Just listing any tiny fraction of what matplotlib is based on would be daunting!
3. Of course, declaring this information is only the first step; it also needs to be shown in the actual rendered site. I was imagining using a compact logo for each one like ![image](https://user-images.githubusercontent.com/1695496/70926921-9aa15600-1ff3-11ea-94ae-c06450ab4aec.png), displayed just as for the Sponsor field.  But once there are lots of logos they may not be as recognizable and distinguishable as matplotlib/bokeh/plotly are, which is another reason to limit the number of technologies to list. Note that each library may be built on many technologies; so far the maximum is 3 in the current declarations.