### PR TITLE
Add non-github repo for graph-tool

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -265,6 +265,10 @@
       site: https://clustergrammer.readthedocs.io
       badges: pypi, site
 
+    - repo: skewed/graph-tool
+      site: http://graph-tool.skewed.de
+      badges: pypi, rtd
+
 - name: Large-data rendering
   intro: Tools for rasterizing/aggregating data before visualization, which can make rendering faster, allow larger datasets, or make it feasible to use remote datasets (with server-side rendering).
   packages:

--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -267,7 +267,7 @@
 
     - repo: skewed/graph-tool
       site: http://graph-tool.skewed.de
-      badges: pypi, rtd
+      badges: pypi, site
 
 - name: Large-data rendering
   intro: Tools for rasterizing/aggregating data before visualization, which can make rendering faster, allow larger datasets, or make it feasible to use remote datasets (with server-side rendering).


### PR DESCRIPTION
Attempt to add graph-tool, even though it has no Github repo (see https://github.com/pyviz/pyviz.org/issues/59).  There will probably be some broken image links (e.g. no github stars), but maybe it will otherwise work?  We'll see what  happens at https://pyviz-dev.github.io/website/tools.html 