### PR TITLE
Add napari to tools

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -121,6 +121,12 @@
       conda_channel: conda-forge
       site: https://veusz.github.io
 
+    - repo: napari/napari
+      site: https://napari.org/
+      conda_channel: conda-forge
+      badges: codecov, pypi, conda
+      builton: vispy
+      
 - name: Other InfoVis
   intro: InfoVis plotting libraries not fitting into other categories above.
   packages:


### PR DESCRIPTION
I'd like to add napari to the `Native-GUI` part of the tools page. I've tried to include some of our badges but let me know if there are others I could add too based on our https://github.com/napari/napari or if I made any errors there. I'm ccing @jni and @HagaiHargil for visibility.

Also I wanted to add I'm very excited to have napari listed up there with so many amazing python visualization tools. Thanks for maintaining this list!!