### PR TITLE
Added mpl to native and bokeh to dashboarding sections

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -102,8 +102,13 @@
       builton: matplotlib
 
 - name: Native-GUI
-  intro: InfoVis Libraries targetting native-desktop GUI interfaces for interactive plots (also see Matplotlib in core above).
+  intro: InfoVis Libraries targetting native-desktop GUI interfaces for interactive plots.
   packages:
+
+    - repo: matplotlib/matplotlib
+      sponsors: [numfocus]
+      badges: travis, appveyor, codecov, pypi, conda, site
+      builton: matplotlib
 
     - repo: pyqtgraph/pyqtgraph
       site: http://www.pyqtgraph.org
@@ -428,8 +433,13 @@
       badges: travis, appveyor, pypi, conda, site
 
 - name: Dashboarding
-  intro: Libraries for creating live Python-backed web applications or dashboards that a user can interact with to explore or analyze data. Also see Bokeh, under Core tools above.
+  intro: Libraries for creating live Python-backed web applications or dashboards that a user can interact with to explore or analyze data.
   packages:
+
+    - repo: bokeh/bokeh
+      sponsors: [numfocus, anaconda]
+      badges: travis, pypi, conda, site
+      builton: bokeh
 
     - repo: plotly/dash
       sponsors: [plotly]


### PR DESCRIPTION
Various people have found it confusing not to have Matplotlib listed in the native-GUI section, as it's the most popular library for that, and similarly for Bokeh in dashboarding. There are others that could also be duplicated, such as HoloViews/Bokeh/Matplotlib in the Network section, but that seems less crucial, and those tools only have limited network-plotting support and so don't stand out as glaring omissions the way these two did.