### PR TITLE
Explicitely list the defaults channel

### DIFF
--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -18,6 +18,7 @@ commands:
       nbsite build --what=html --output=builtdocs
 
 channels:
+- defaults
 - pyviz
 - conda-forge
 


### PR DESCRIPTION
The project broke after the last release of anaconda-project.