### PR TITLE
Remove the link to examples.pyviz.org

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,4 +12,3 @@
    Dashboarding <dashboarding/index>
    SciVis <scivis/index>
    Tutorials <tutorials/index>
-   Topics <https://examples.pyviz.org>


### PR DESCRIPTION
In preparation of examples.pyviz.org migrating to examples.holoviz.org and being dedicated to HoloViz examples, it is fair to remove this link from this general website.