### PR TITLE
Add jupyter-scatter

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -184,6 +184,12 @@
 
     - repo: maxhumber/chart
 
+    - repo: flekschas/jupyter-scatter
+      badges: pypi, site
+      builtons: [webgl]
+      pypi_name: jupyter-scatter
+      site: https://jupyter-scatter.dev/
+
 
 - name: SciVis
   intro: Libraries for visualizing scientific data situated in real-world coordinates, typically using OpenGL or WebGL.


### PR DESCRIPTION
This PR adds [Jupyter Scatter](https://github.com/flekschas/jupyter-scatter) to the `Other InfoVis` section. Jupyter Scatter is an interactive scatter plot widget for Jupyter Notebook, Lab, and Google Colab that can handle millions of points and supports linking of multiple scatter plot instances. I presented the tool at [this year's SciPy conference](https://www.youtube.com/watch?v=RyC5ixtQG-Q) (in case it helps to contextualize the tool).

Even though Jupyter Scatter can render up to several million data points, it doesn't seem to fit the `Large-data rendering` category as it doesn't aggregate/rasterize the data prior to visualization.