### PR TITLE
Update xarray tools info

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -33,7 +33,8 @@
     - repo: pydata/xarray
       sponsors: [numfocus]
       appveyor_project: shoyer/xray
-      site: https://xarray.pydata.org
+      site: https://xarray.dev/
+      conda-channel: conda-forge
       badges: travis, appveyor, coveralls, rtd, pypi, conda, site
       builtons: [matplotlib]
 


### PR DESCRIPTION
I noticed during a SciPy 2024 tutorial that the Xarray Anaconda badge version was outdated (it showed v2023.6.0 instead of the current v2024.6.0). This PR updates the entry to add the conda-forge channel (and updates the Xarray home page url).