### PR TITLE
add pypalettes to colormapping

### DIFF
--- a/tools/tools.yml
+++ b/tools/tools.yml
@@ -862,6 +862,11 @@
       conda_channel: conda-forge
       badges: travis, codecov, pypi, conda
 
+    - repo: y-sunflower/pypalettes
+      site: https://python-graph-gallery.com/color-palette-finder/
+      badges: pypi, conda, site
+      builtons: [matplotlib]
+
 - name: Dormant projects
   intro: Tools no longer developed or endorsed by the authors.
   packages:


### PR DESCRIPTION
Hi @jbednar !

In this PR I add [pypalettes](https://github.com/y-sunflower/pypalettes), which is one of the package I maintain at [yellow sunflower](https://github.com/y-sunflower) (a brand new organization I recently created).

On a more or less separate note, I wonder if pyviz is opened to add more specific packages in the "all tools" section? I have many other projects that I think are cool, but they might be too specific for pyviz.org?

I'm mainly thinking:
- [pyfonts](https://github.com/y-sunflower/pyfonts): working with fonts in matplotlib
- [drawarrow](https://github.com/y-sunflower/drawarrow): working with arrows in matplotlib
- [morethemes](https://github.com/y-sunflower/morethemes): themes for matplotlib
- (there are several others, but they are not considered stable or are chart-specific)

Let me know what you think.